### PR TITLE
Support input value for platform build definition

### DIFF
--- a/.github/workflows/turkeyGitops.yml
+++ b/.github/workflows/turkeyGitops.yml
@@ -40,6 +40,9 @@ on:
       docker_args-env:
         type: string
         default: '-'
+      platforms:
+        type: string
+        default: 'linux/amd64'
     secrets:
       DOCKER_HUB_PWD:
         required: true
@@ -84,6 +87,7 @@ jobs:
       - name: docker build(x) push
         uses: docker/build-push-action@v2
         with:
+          platforms: ${{ inputs.platforms }}
           context: repo/
           file: repo/${{ inputs.dockerfile }}
           tags: ${{ inputs.registry }}/${{ github.workflow }}:latest,${{ inputs.registry }}/${{ github.workflow }}:${{ github.run_number }}


### PR DESCRIPTION
## What?

Enables support for platform cross docker builds. This is a first step to adding Hubs arm64 build support
 
## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
This adds a new input variable to alllow customisation of docker builds, which defaults to `linux/amd64` which is the current default. Therefore default behvaiour will not change

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->

N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

Run GitHub CI

## Documentation of functionality

N/A

## Limitations

N/A

## Alternatives considered

N/A

## Open questions

N/A

## Additional details or related context

N/A
