### PR TITLE
actions in turkeyGitops.yml are updated to current

### DIFF
--- a/.github/workflows/turkeyGitops.yml
+++ b/.github/workflows/turkeyGitops.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: "./repo"
       - name: use codePath for multirepo
@@ -73,7 +73,7 @@ jobs:
           mv ./_repo ./repo
           ls ./repo
       - name: docker setup buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
       - name: docker build
@@ -89,7 +89,7 @@ jobs:
             CONTENTFUL_TOKEN_b64=$${{ secrets.docker_args-contentful_token_b64 }}
       - name: docker login
         if: ${{ github.repository_owner == 'Hubs-Foundation' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ inputs.DOCKER_HUB_USR }}
           password: ${{ secrets.DOCKER_HUB_PWD }}


### PR DESCRIPTION
## What?
Updates actions/checkout to v4, docker/setup-buildx-action to v3, and docker/login-action to v3


## Why?
Current versions don't throw distracting warnings and presumably function better in some cases

## How to test
1. for a non-Foundation repo that uses turkeyGitOps, modify the script to use this version
2. create a new branch (no need to add any commits)
3. push the new branch, observe that checkout and build complete normally
4. delete the new branch
5. for a Foundation repo that uses turkeyGitOps, modify the script to use this version
6. create a new branch (no need to add any commits)
7. push the new branch, observe that checkout, build, login and push complete normally
8. delete the new branch

## Documentation of functionality
no docs changes; it should have always worked this way

